### PR TITLE
require space between "#" and heading text

### DIFF
--- a/markdown_parser.leg
+++ b/markdown_parser.leg
@@ -56,7 +56,7 @@ AtxInline = !Newline !(Sp? '#'* Sp Newline) Inline
 AtxStart =  < ( "######" | "#####" | "####" | "###" | "##" | "#" ) >
             { $$ = mk_element(H1 + (strlen(yytext) - 1)); }
 
-AtxHeading = s:AtxStart Sp? a:StartList ( AtxInline { a = cons($$, a); } )+ (Sp? '#'* Sp)?  Newline
+AtxHeading = s:AtxStart Spacechar+ a:StartList ( AtxInline { a = cons($$, a); } )+ (Sp? '#'* Sp)?  Newline
             { $$ = mk_list(s->key, a);
               free(s); }
 


### PR DESCRIPTION
According to the reference implementation of atx (http://www.aaronsw.com/2002/atx/atx.py), there needs to be a space between a hash and the heading text.

Example:

`#chapter one` --->
# chapter one

`# chapter two` --->
# chapter two
