### PR TITLE
New extension: hard wrap

### DIFF
--- a/markdown.c
+++ b/markdown.c
@@ -71,6 +71,7 @@ int main(int argc, char * argv[]) {
     static gboolean opt_notes = FALSE;
     static gboolean opt_filter_html = FALSE;
     static gboolean opt_filter_styles = FALSE;
+    static gboolean opt_hardwrap = FALSE;
     static gboolean opt_allext = FALSE;
 
     static GOptionEntry entries[] =
@@ -87,8 +88,9 @@ int main(int argc, char * argv[]) {
     /* Options to active syntax extensions.  These appear separately in --help. */
     static GOptionEntry ext_entries[] =
     {
-      { "smart", 0, 0, G_OPTION_ARG_NONE, &opt_smart, "use smart typography extension", NULL },
-      { "notes", 0, 0, G_OPTION_ARG_NONE, &opt_notes, "use notes extension", NULL },
+      { "smart",    0, 0, G_OPTION_ARG_NONE, &opt_smart,    "use smart typography extension", NULL },
+      { "notes",    0, 0, G_OPTION_ARG_NONE, &opt_notes,    "use notes extension", NULL },
+      { "hardwrap", 0, 0, G_OPTION_ARG_NONE, &opt_hardwrap, "respect linebreaks in paragraphs", NULL },
       { NULL }
     };
 
@@ -127,6 +129,8 @@ int main(int argc, char * argv[]) {
         extensions = extensions | EXT_FILTER_HTML;
     if (opt_filter_styles)
         extensions = extensions | EXT_FILTER_STYLES;
+    if (opt_hardwrap)
+        extensions = extensions | EXT_HARD_WRAP;
 
     if (opt_to == NULL)
         output_format = HTML_FORMAT;

--- a/markdown_lib.h
+++ b/markdown_lib.h
@@ -6,7 +6,8 @@ enum markdown_extensions {
     EXT_SMART            = 0x01,
     EXT_NOTES            = 0x02,
     EXT_FILTER_HTML      = 0x04,
-    EXT_FILTER_STYLES    = 0x08
+    EXT_FILTER_STYLES    = 0x08,
+    EXT_HARD_WRAP        = 0x40
 };
 
 enum markdown_formats {

--- a/markdown_parser.leg
+++ b/markdown_parser.leg
@@ -430,7 +430,7 @@ NormalEndline =   Sp Newline !BlankLine !'>' !AtxStart
 TerminalEndline = Sp Newline Eof
                   { $$ = NULL; }
 
-LineBreak = "  " NormalEndline
+LineBreak = ( "  " NormalEndline | &{ extension(EXT_HARD_WRAP) } NormalEndline )
             { $$ = mk_element(LINEBREAK); }
 
 Symbol =    < SpecialChar >


### PR DESCRIPTION
Insert linebreaks inside paragraphs where the origin Markdown document
had newlines (by default, Markdown ignores these newlines). This has been
modelled after the hard_wrap extension supported by Redcarpet.

`EXT_HARD_WRAP`
`--hardwrap`
